### PR TITLE
Check for empty hash in getMessages()#50Mel

### DIFF
--- a/api/application/Application.php
+++ b/api/application/Application.php
@@ -69,6 +69,8 @@ class Application {
     }
     
     public function getMessages($params) {
+        if($params['hash'] == 'null') return "ERROR: EMPTY HASH";
+
         $user = $this->user->getUser($params['token']);
         if ($user) {
             return $this->chat->getMessages($params['hash'], $user);


### PR DESCRIPTION
1. Проверка должна быть _**ПЕРЕД**_ getUser(), чтобы лишний раз не нагружать БД.
2. Если 'hash' == null возращаем строку, а не просто выходим из getMessages через return.
    Так, даем понять клиенту что его запрос дошел до нас, но сам по себе он ошибочен. (пустой hash)